### PR TITLE
Do not require local.properties file to build plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,10 @@ artifacts {
 
 // Bintray
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+File properties_file = project.rootProject.file('local.properties')
+if (properties_file.exists()) {
+  properties.load(properties_file.newDataInputStream())
+}
 
 bintray {
     user = properties.getProperty("bintray.user")


### PR DESCRIPTION
Check for existence of `local.properties` before reading from it

Before:
```
$ git clone https://github.com/timmutton/redex-plugin.git
$ cd redex-plugin
$ gradle build
...
FAILURE: Build failed with an exception.

* Where:
Build file '/home/jhendrick/redex-plugin/build.gradle' line: 58
```

After:
```
$ gradle build
...
BUILD SUCCESSFUL in 14s
7 actionable tasks: 7 executed
```