### PR TITLE
Read config file from disk

### DIFF
--- a/src/main/kotlin/au/com/timmutton/redexplugin/RedexPlugin.kt
+++ b/src/main/kotlin/au/com/timmutton/redexplugin/RedexPlugin.kt
@@ -17,7 +17,8 @@ class RedexPlugin : Plugin<Project> {
 
             val android = project.extensions.getByType(AppExtension::class.java)
 
-            RedexTask.passes =  project.extensions.getByType(RedexPluginExtension::class.java).passes
+            RedexTask.configFilePath = project.extensions.getByType(RedexPluginExtension::class.java).configFilePath
+            RedexTask.passes = project.extensions.getByType(RedexPluginExtension::class.java).passes
             RedexTask.sdkDirectory = android.sdkDirectory.toString()
 
             for(variant in android.applicationVariants) {

--- a/src/main/kotlin/au/com/timmutton/redexplugin/RedexPlugin.kt
+++ b/src/main/kotlin/au/com/timmutton/redexplugin/RedexPlugin.kt
@@ -17,8 +17,9 @@ class RedexPlugin : Plugin<Project> {
 
             val android = project.extensions.getByType(AppExtension::class.java)
 
-            RedexTask.configFilePath = project.extensions.getByType(RedexPluginExtension::class.java).configFilePath
-            RedexTask.passes = project.extensions.getByType(RedexPluginExtension::class.java).passes
+            val extension = project.extensions.getByType(RedexPluginExtension::class.java)
+            RedexTask.configFilePath = extension.configFilePath
+            RedexTask.passes = extension.passes
             RedexTask.sdkDirectory = android.sdkDirectory.toString()
 
             for(variant in android.applicationVariants) {

--- a/src/main/kotlin/au/com/timmutton/redexplugin/RedexPluginExtension.kt
+++ b/src/main/kotlin/au/com/timmutton/redexplugin/RedexPluginExtension.kt
@@ -4,14 +4,6 @@ package au.com.timmutton.redexplugin
  * @author timmutton
  */
 open class RedexPluginExtension {
-    var passes: Array<String> = arrayOf("ReBindRefsPass",
-                                        "BridgePass",
-                                        "SynthPass",
-                                        "FinalInlinePass",
-                                        "DelSuperPass",
-                                        "SingleImplPass",
-                                        "SimpleInlinePass",
-                                        "StaticReloPass",
-                                        "RemoveEmptyClassesPass",
-                                        "ShortenSrcStringsPass")
+    var configFilePath : String? = null
+    var passes: Array<String>? = null
 }


### PR DESCRIPTION
This is my first time writing Kotlin, so feel free to tell me if I'm doing this the wrong way.

I want to preserve functionality of `redex.passes` while also adding `redex.configFilePath`. It is an error to supply both at once.

I deleted the pass list in `RedexPluginExtension.kt` because it's the exact same as [the default if no config file is provided to redex](https://github.com/facebook/redex/blob/master/tools/redex-all/main.cpp#L154).